### PR TITLE
Renamed toMap, fromMap

### DIFF
--- a/src/main/kotlin/andrasferenczi/templater/TemplateConstants.kt
+++ b/src/main/kotlin/andrasferenczi/templater/TemplateConstants.kt
@@ -6,8 +6,8 @@ object TemplateConstants {
     const val COPYWITH_DEFAULT_METHOD_NAME = "copyWith"
 
     const val MAP_VARIABLE_NAME = "map"
-    const val TO_MAP_METHOD_NAME = "toMap"
-    const val FROM_MAP_METHOD_NAME = "fromMap"
+    const val TO_MAP_METHOD_NAME = "toJson"
+    const val FROM_MAP_METHOD_NAME = "fromJson"
 
     const val KEYMAPPER_VARIABLE_NAME = "keyMapper"
     const val KEY_VARIABLE_NAME = "key"


### PR DESCRIPTION
Renamed methods to `toJson` and `fromJson` for compatibility with `json_serializable` plugin and conventional naming practices.

/closes #3 